### PR TITLE
Add the ability for the user to enter numbers into the GUI board

### DIFF
--- a/src/sudoku_solver/board.py
+++ b/src/sudoku_solver/board.py
@@ -33,6 +33,7 @@ class House:
 class Board:
   def __init__(self, board:board_t):
     self.board = board
+    self.selected_cell = (0, 0)  # P31fe
 
   def __str__(self):
     board_str = str()
@@ -80,3 +81,9 @@ class Board:
         freg = self.board[i:i+3, j:j+3].flatten()
         regs= np.append(regs, [freg], axis=0)
     return regs
+
+  def update_cell(self, row: DimIdx, col: DimIdx, value: int):  # P6790
+    self.board[row][col] = value
+
+  def get_cell_value(self, row: DimIdx, col: DimIdx) -> int:  # Pd6fe
+    return self.board[row][col]

--- a/src/sudoku_solver/ui.py
+++ b/src/sudoku_solver/ui.py
@@ -12,6 +12,7 @@ class SudokuGUI:
         self.board = board
         self.font = pygame.font.SysFont(None, 40)
         self.message = ""
+        self.selected_cell = (0, 0)
 
     def draw_board(self):
         self.screen.fill((255, 255, 255))
@@ -27,6 +28,8 @@ class SudokuGUI:
                 if self.board.board[r][c] != 0:
                     text = self.font.render(str(self.board.board[r][c]), True, (0, 0, 0))
                     self.screen.blit(text, (c * 60 + 20, r * 60 + 15))
+        pygame.draw.rect(self.screen, (255, 0, 0), (self.selected_cell[1] * 60, self.selected_cell[0] * 60, 60, 60), 3)
+        self.highlight_same_numbers()
         if self.message:
             message_text = self.font.render(self.message, True, (255, 0, 0))
             self.screen.blit(message_text, (10, 550))
@@ -44,11 +47,44 @@ class SudokuGUI:
         self.message = message
         self.draw_board()
 
+    def handle_key_event(self, event):
+        if event.key in range(pygame.K_1, pygame.K_10):
+            num = event.key - pygame.K_0
+            self.board.board[self.selected_cell[0]][self.selected_cell[1]] = num
+            self.draw_board()
+        elif event.key == pygame.K_UP:
+            self.selected_cell = (max(self.selected_cell[0] - 1, 0), self.selected_cell[1])
+        elif event.key == pygame.K_DOWN:
+            self.selected_cell = (min(self.selected_cell[0] + 1, 8), self.selected_cell[1])
+        elif event.key == pygame.K_LEFT:
+            self.selected_cell = (self.selected_cell[0], max(self.selected_cell[1] - 1, 0))
+        elif event.key == pygame.K_RIGHT:
+            self.selected_cell = (self.selected_cell[0], min(self.selected_cell[1] + 1, 8))
+        self.draw_board()
+
+    def handle_mouse_event(self, event):
+        if event.button == 1:  # Left mouse button
+            pos = pygame.mouse.get_pos()
+            self.selected_cell = (pos[1] // 60, pos[0] // 60)
+            self.draw_board()
+
+    def highlight_same_numbers(self):
+        selected_value = self.board.board[self.selected_cell[0]][self.selected_cell[1]]
+        if selected_value != 0:
+            for r in range(9):
+                for c in range(9):
+                    if self.board.board[r][c] == selected_value and (r, c) != self.selected_cell:
+                        pygame.draw.rect(self.screen, (0, 255, 0), (c * 60, r * 60, 60, 60), 3)
+
     def run(self):
         running = True
         while running:
             for event in pygame.event.get():
                 if event.type == pygame.QUIT:
                     running = False
+                elif event.type == pygame.KEYDOWN:
+                    self.handle_key_event(event)
+                elif event.type == pygame.MOUSEBUTTONDOWN:
+                    self.handle_mouse_event(event)
             self.draw_board()
         pygame.quit()


### PR DESCRIPTION
Add the ability for the user to enter numbers into the GUI board and highlight cells with the same number.

* Add `handle_key_event` method to handle user input for number keys and arrow keys in `src/sudoku_solver/ui.py`
* Modify `run` method to call `handle_key_event` when a key is pressed in `src/sudoku_solver/ui.py`
* Update `draw_board` method to highlight the selected cell and call `highlight_same_numbers` in `src/sudoku_solver/ui.py`
* Add `handle_mouse_event` method to handle mouse clicks on cells in `src/sudoku_solver/ui.py`
* Add `highlight_same_numbers` method to highlight cells with the same number as the selected cell in `src/sudoku_solver/ui.py`
* Add `update_cell` method to update the value of a cell in `src/sudoku_solver/board.py`
* Modify `__init__` method to initialize a selected cell attribute in `src/sudoku_solver/board.py`
* Add `get_cell_value` method to get the value of a cell in `src/sudoku_solver/board.py`

