### PR TITLE
Add undo and solve buttons to the UI

### DIFF
--- a/src/sudoku_solver/board.py
+++ b/src/sudoku_solver/board.py
@@ -87,3 +87,9 @@ class Board:
 
   def get_cell_value(self, row: DimIdx, col: DimIdx) -> int:  # Pd6fe
     return self.board[row][col]
+
+  def get_board_state(self):  # P113a
+    return self.board.copy()
+
+  def set_board_state(self, state):  # Pe2aa
+    self.board = state.copy()

--- a/src/sudoku_solver/logic.py
+++ b/src/sudoku_solver/logic.py
@@ -64,3 +64,9 @@ def brute_force_solve(board: Board) -> bool:
             board.update_cell(row, col, 0)
 
     return False
+
+def store_board_state(board: Board):
+    return board.board.copy()
+
+def restore_board_state(board: Board, state):
+    board.board = state.copy()

--- a/src/sudoku_solver/ui.py
+++ b/src/sudoku_solver/ui.py
@@ -2,17 +2,18 @@
 
 import pygame
 from sudoku_solver.board import Board
-from sudoku_solver.logic import solve_sudoku
+from sudoku_solver.logic import solve_sudoku, brute_force_solve
 
 class SudokuGUI:
     def __init__(self, board: Board):
         pygame.init()
-        self.screen = pygame.display.set_mode((540, 540))
+        self.screen = pygame.display.set_mode((540, 600))
         pygame.display.set_caption("Sudoku Solver")
         self.board = board
         self.font = pygame.font.SysFont(None, 40)
         self.message = ""
         self.selected_cell = (0, 0)
+        self.history = []
 
     def draw_board(self):
         self.screen.fill((255, 255, 255))
@@ -33,14 +34,26 @@ class SudokuGUI:
         if self.message:
             message_text = self.font.render(self.message, True, (255, 0, 0))
             self.screen.blit(message_text, (10, 550))
+        self.draw_buttons()
         pygame.display.flip()
+
+    def draw_buttons(self):
+        solve_button = pygame.Rect(10, 560, 100, 30)
+        undo_button = pygame.Rect(120, 560, 100, 30)
+        pygame.draw.rect(self.screen, (0, 0, 0), solve_button)
+        pygame.draw.rect(self.screen, (0, 0, 0), undo_button)
+        solve_text = self.font.render("Solve", True, (255, 255, 255))
+        undo_text = self.font.render("Undo", True, (255, 255, 255))
+        self.screen.blit(solve_text, (20, 565))
+        self.screen.blit(undo_text, (130, 565))
 
     def update_board(self, board: Board):
         self.board = board
         self.draw_board()
 
     def solve_and_update(self):
-        solve_sudoku(self.board)
+        self.save_state()
+        brute_force_solve(self.board)
         self.update_board(self.board)
 
     def display_message(self, message: str):
@@ -50,6 +63,7 @@ class SudokuGUI:
     def handle_key_event(self, event):
         if event.key in range(pygame.K_1, pygame.K_10):
             num = event.key - pygame.K_0
+            self.save_state()
             self.board.board[self.selected_cell[0]][self.selected_cell[1]] = num
             self.draw_board()
         elif event.key == pygame.K_UP:
@@ -65,7 +79,13 @@ class SudokuGUI:
     def handle_mouse_event(self, event):
         if event.button == 1:  # Left mouse button
             pos = pygame.mouse.get_pos()
-            self.selected_cell = (pos[1] // 60, pos[0] // 60)
+            if 560 <= pos[1] <= 590:
+                if 10 <= pos[0] <= 110:
+                    self.solve_and_update()
+                elif 120 <= pos[0] <= 220:
+                    self.undo()
+            else:
+                self.selected_cell = (pos[1] // 60, pos[0] // 60)
             self.draw_board()
 
     def highlight_same_numbers(self):
@@ -75,6 +95,14 @@ class SudokuGUI:
                 for c in range(9):
                     if self.board.board[r][c] == selected_value and (r, c) != self.selected_cell:
                         pygame.draw.rect(self.screen, (0, 255, 0), (c * 60, r * 60, 60, 60), 3)
+
+    def save_state(self):
+        self.history.append(self.board.board.copy())
+
+    def undo(self):
+        if self.history:
+            self.board.board = self.history.pop()
+            self.draw_board()
 
     def run(self):
         running = True


### PR DESCRIPTION
Add a new row at the bottom of the UI for buttons, including a solve button and an undo button.

* **UI Changes**
  - Increase the window height to accommodate the new row for buttons.
  - Add `draw_buttons` method to draw the solve and undo buttons.
  - Modify `handle_mouse_event` to handle button clicks for solving the board and undoing the last action.
  - Add `save_state` method to store the current board state before each action.
  - Add `undo` method to restore the board state to the previous state.

* **Logic Changes**
  - Add `store_board_state` function to store the current board state.
  - Add `restore_board_state` function to restore the board state to a previous state.

* **Board Changes**
  - Add `get_board_state` method to get the current board state.
  - Add `set_board_state` method to set the board state.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/solarisin/sudoku-solver/pull/7?shareId=eaa2e5cc-1070-4b21-a3fd-5143ac9c4de6).