### PR TITLE
Fix failing GitHub action

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -32,6 +32,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-poetry-
 
+      - name: Generate lock file
+        run: poetry lock
+
       - name: Install dependencies
         run: |
           poetry install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,10 @@ python = ">=3.11"
 beartype = "^0.20.2"
 numpy = "^2.2.4"
 click = "^8.0.0"
-pytest = "^6.2.4"
-pytest-pygame = "^0.1.0"
+
+[tool.poetry.dev-dependencies]
+pytest = "^6.0"
+pytest-pygame = "^2.0"
 
 [tool.pytest.ini_options]
 minversion = "6.0"


### PR DESCRIPTION
Update dependencies and GitHub action to fix failing test runner.

* **pyproject.toml**
  - Remove `pytest` and `pytest-pygame` from `[tool.poetry.dependencies]`
  - Add `pytest` and `pytest-pygame` to `[tool.poetry.dev-dependencies]`

* **.github/workflows/run-tests.yml**
  - Add a step to run `poetry lock` before installing dependencies

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/solarisin/sudoku-solver/pull/10?shareId=7078bafb-0612-4f8e-be2d-2da1b5adf6de).